### PR TITLE
Fix bug and add cross-plugin compatibility in search box

### DIFF
--- a/keyboard-navigation.js.tid
+++ b/keyboard-navigation.js.tid
@@ -61,18 +61,15 @@ document.onkeydown = function(e) {
 			&& activeElement.classList.contains("tc-popup-handle")) {
 		if (e.key == "Tab" || e.key == "Enter") {
 			// if in search box and there are matches, jump to (and open) first match
-			var elements = document.getElementsByClassName("tc-search-results");
-			if (!elements) return;
-			if (!elements[0]) return;
-			if (!elements[0].getElementsByTagName("div")[0]) return;
-			if (!elements[0].getElementsByTagName("div")[0].children[0]) return;
-			// focus first match (if any)
-			elements[0].getElementsByTagName("div")[0].children[0].focus();
-			if (e.key == "Enter") {
-				// when Enter was pressed, also open the first match
-				elements[0].getElementsByTagName("div")[0].children[0].click();
+			var searchItems = document.querySelector("div.tc-search-results div.tc-menu-list-item")
+			if (searchItems) {
+				searchItems.children[0].focus();
+				if (e.key == "Enter") {
+					// when Enter was pressed, also open the first match
+					searchItems.children[0].click();
+				}
+				e.preventDefault();
 			}
-			e.preventDefault();
 		}
 	}
 }

--- a/keyboard-navigation.js.tid
+++ b/keyboard-navigation.js.tid
@@ -136,6 +136,7 @@ document.onkeyup = function(e) {
 		if (tiddler_index < 0) return;
 		if (!isInViewport(tiddlers[tiddler_index])) return;
 		var button = tiddlers[tiddler_index].getElementsByClassName('tc-btn-%24%3A%2Fcore%2Fui%2FButtons%2Fclose')[0];
+		if (!button) return;
 		button.click();
 		if (tiddlers.length == 1) return;  // no tiddler left (after closing the last one)
 		if (tiddler_index >= tiddlers.length - 1) tiddler_index = tiddlers.length-2;


### PR DESCRIPTION
Thanks for this plugin! I ran into a couple glitches getting this to work in my wiki that others will likely see as well sooner or later, so went ahead and corrected them. See the messages on the commits for details, but basically:

* The Locator plugin adds tags to the search box, which made Tab and Enter do nothing at all. Changed the selection method to use `querySelector()` in a way that works both with and without the Locator plugin.
* Pressing `c` on a tiddler in edit mode causes a JavaScript error dialog. Added a null check to avoid this.