### PR TITLE
Generalised keybind code to all tiddler buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,13 @@ Press `Esc` to unfocus the sidebar search field.
 Then you can jump to the next or previous open tiddler in the story river by pressing `j` or `k`, respectively.
 Press `e` if you want to edit the current tiddler. Press `Ctrl+Return` when you're done (as usual).
 `c` is for closing a tiddler.
+`d` is for deleting a tiddler.
 
 When you search your TiddlyWiki (`Ctrl+Shift+f` by default), just press `Return` to open or `Tab` to focus the first match (without this plugin you have to press `Tab` four times).
+
+## Adding / Changing keybinds
+You can bind keys to any of the tiddler buttons (permalink, export, etc). Here is how you do it:
+1. Install this plugin
+2. Refresh and find it in your Plugins tab in ControlPanel
+3. Open the keyboard-navigation.js file
+4. Near the top just edit the ```bindings``` variable for more functionality, or the ```navigate_up_key``` and ```navigate_down_key``` to change the keys used for navigation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tw5-keyboard-navigation
-Navigate through your TiddlyWiki5 with your keyboard: jump to next/previous tiddler, edit or close tiddler
+Navigate through your TiddlyWiki5 with your keyboard: jump to next/previous tiddler, edit, close, and more.
+
+Any actions that can be performed by the view toolbar buttons can be performed with keybinds using this plugin.
 
 ## Demonstration/Installation
 Check [this demonstration](https://maximilian-schillinger.de/tw5-keyboard-navigation-plugin.html) of tw-keyboard-navigation! You can integrate `tw5-keyboard-navigation` by dragging the plugin tiddler from the demo page into your TiddlyWiki.
@@ -9,7 +11,6 @@ Press `Esc` to unfocus the sidebar search field.
 Then you can jump to the next or previous open tiddler in the story river by pressing `j` or `k`, respectively.
 Press `e` if you want to edit the current tiddler. Press `Ctrl+Return` when you're done (as usual).
 `c` is for closing a tiddler.
-`d` is for deleting a tiddler.
 
 When you search your TiddlyWiki (`Ctrl+Shift+f` by default), just press `Return` to open or `Tab` to focus the first match (without this plugin you have to press `Tab` four times).
 
@@ -19,3 +20,8 @@ You can bind keys to any of the tiddler buttons (permalink, export, etc). Here i
 2. Refresh and find it in your Plugins tab in ControlPanel
 3. Open the keyboard-navigation.js file
 4. Near the top just edit the `bindings` variable for more functionality, or the `navigate_up_key` and `navigate_down_key` to change the keys used for navigation
+
+## Note on button functionality
+Your keybinds will only work when you have the corresponding buttons enabled in the View Toolbar. So for example, if you have `c` bound to close a tiddler, if you go to ```ControlPanel -> Appearance -> Toolbars -> View Toolbar``` and disable the close button, your `c` keybind will not work.
+
+This is because this functionality works by using the DOM elements (the toolbar buttons), so if you remove them, they can't be "clicked" by this plugin.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ You can bind keys to any of the tiddler buttons (permalink, export, etc). Here i
 1. Install this plugin
 2. Refresh and find it in your Plugins tab in ControlPanel
 3. Open the keyboard-navigation.js file
-4. Near the top just edit the ```bindings``` variable for more functionality, or the ```navigate_up_key``` and ```navigate_down_key``` to change the keys used for navigation
+4. Near the top just edit the `bindings` variable for more functionality, or the `navigate_up_key` and `navigate_down_key` to change the keys used for navigation

--- a/keyboard-navigation.js.tid
+++ b/keyboard-navigation.js.tid
@@ -206,7 +206,7 @@ document.onkeyup = function(e) {
 	var up_key_released = ignoreKeyboardLayout ? (e.code == ("Key" + navigate_up_key.toUpperCase())) : (e.key == navigate_up_key);
 	var other_bind_used = Object.keys(bindings).find(k => {
 		if (!bindings[k]) return false;
-		if (ignoreKeyboardLayout) return e.code == ("Key" + bindings[k].toUpperCase()) && !alternateLayoutIgnoreKeys.find(k => k == e.key);
+		if (ignoreKeyboardLayout) return e.code == ("Key" + bindings[k].toUpperCase()) && !alternateLayoutIgnoreKeys.find(ak => ak == e.key);
 		return e.key == bindings[k];
 	})
 

--- a/keyboard-navigation.js.tid
+++ b/keyboard-navigation.js.tid
@@ -15,11 +15,37 @@ exports.name = "tw5-keyboard-navigation"; exports.after = ["rootwidget"];
 
 exports.startup = function () {
 
+// Keybinds section
+const navigate_up_key = 'k'
+const navigate_down_key = 'j'
+const bindings = {
+	more: null,
+	info: null,
+	'new-here': null,
+	'new-journal-here': null,
+	clone: null,
+	'export-tiddler': null,
+	edit: 'e',
+	delete: 'd',
+	permalink: null,
+	permaview: null,
+	'open-window': null,
+	'close-others': null,
+	close: 'c',
+	'fold-others': null,
+	fold: null
+}
+// if you just want to add/change keybindings, you don't need to look further
+
+
+const BTN_CLASSNAME_PREFIX = 'tc-btn-%24%3A%2Fcore%2Fui%2FButtons%2F' // tiddler buttons have classnames in the form {BTN_CLASSNAME_PREFIX}{button name}
+const INSTANT_NAVIGATION = false; // all transitions with {navigate_up_key} and {navigate_down_key} are instant
+const INSTANT_NAVIGATION_BEFORE = 800; // if navigated before x milliseconds, transition is instant
+
 const MARK_CURRENT_TIDDLER = true;
 // tiddler's top position should be +/- LIMIT pixels in order to be considered the topmost
 const LIMIT = 50;
 
-var ignoreKeyboardLayout = false;
 var cycle = false;
 var tiddlers;
 var tiddler_index = -1;
@@ -167,17 +193,12 @@ document.onkeyup = function(e) {
 	tiddlers = document.getElementsByClassName("tc-tiddler-frame");
 	if (tiddlers.length == 0) return;
 
-	var tiddlerIgnoreKeyboardLayout = $tw.wiki.getTiddler("$:/config/IgnoreKeyboardLayout");
-	ignoreKeyboardLayout = (tiddlerIgnoreKeyboardLayout.fields.text.trim() == "1");
-
 	var tiddlerCycle = $tw.wiki.getTiddler("$:/config/Cycle");
 	cycle = (tiddlerCycle.fields.text.trim() == "1");
 
-	var j_released = ignoreKeyboardLayout ? (e.code == "KeyJ") : (e.key == "j");
-	var k_released = ignoreKeyboardLayout ? (e.code == "KeyK") : (e.key == "k");
-	var c_released = ignoreKeyboardLayout ? (e.code == "KeyC") : (e.key == "c");
-	// e: check for ArrowUp because AltGr+E is ArrowUp in Neo2, AdNW, KOY and other keyboard layouts
-	var e_released = ignoreKeyboardLayout ? (e.code == "KeyE" && e.key != "ArrowUp") : (e.key == "e");
+	var down_key_released = e.key == navigate_up_key;
+	var up_key_released = e.key == navigate_down_key;
+	var other_bind_used = Object.keys(bindings).find(k => bindings[k] && e.key == bindings[k])
 
 	if (tiddler_title) {
 		if (tiddler_index < 0 || tiddler_index >= tiddlers.length || tiddlers[tiddler_index].getAttribute("data-tiddler-title") != tiddler_title) {
@@ -192,61 +213,56 @@ document.onkeyup = function(e) {
 		}
 	}
 	var last_tiddler_index = tiddler_index;
-	if (j_released || k_released) {
+
+	if (down_key_released || up_key_released || other_bind_used) {
 		if (tiddler_index < 0 || (!isInViewport(tiddlers[tiddler_index]) && !isElementCloseToTop(tiddlers[tiddler_index]))) {
 			tiddler_index = findTopmostTiddler(tiddlers);
-			if (j_released) tiddler_index -= 1;
+			if (down_key_released) tiddler_index -= 1;
 		}
-		if (j_released) {
-			// go down
-			tiddler_index += 1;
-			if (tiddler_index >= tiddlers.length) tiddler_index = cycle ? 0 : tiddlers.length - 1;
-		} else  {  // e.code == "KeyK"
-			// go up
-			tiddler_index -= 1;
-			if (tiddler_index < 0) tiddler_index = cycle ? tiddlers.length - 1 : 0;
-		}
-		if (Date.now() - timestamp_last_navigation < 800) { // milliseconds
-			// if user navigates quickly, jump instantly to next or previous tiddler
-			tiddlers[tiddler_index].scrollIntoView();
-		} else {
-			// scroll smoothly to next or previous tiddler
-			tiddlers[tiddler_index].scrollIntoView({behavior: "smooth", block: "start", inline: "nearest"});
-		}
-		timestamp_last_navigation = Date.now();
-		if (MARK_CURRENT_TIDDLER) {
-			if (last_tiddler_index >= 0)
-				tiddlers[last_tiddler_index].classList.remove("activeTiddler");
-			tiddlers[tiddler_index].classList.add("activeTiddler");
-		}
-		getActiveTiddlersTitle();
-	} else if (c_released) {
-		// close current tiddler
-		if (tiddlers[tiddler_index] === undefined) return;
-		if (!isInViewport(tiddlers[tiddler_index])) return;
-		var button = tiddlers[tiddler_index].getElementsByClassName("tc-btn-%24%3A%2Fcore%2Fui%2FButtons%2Fclose")[0];
-		if (!button) return;
-		button.click();
-		if (tiddlers.length == 1) return;  // no tiddler left (after closing the only one)
-		// the next tiddler becomes the active one; if the last one was closed, the one before will be activated
-		if (tiddler_index >= tiddlers.length - 1) {
-			tiddler_index = tiddlers.length - 2;
-			if (MARK_CURRENT_TIDDLER)
+		if (down_key_released || up_key_released) {
+			if (down_key_released) {
+				// go down
+				tiddler_index += 1;
+				if (tiddler_index >= tiddlers.length) tiddler_index = cycle ? 0 : tiddlers.length - 1;
+			} else if (up_key_released) {
+				// go up
+				tiddler_index -= 1;
+				if (tiddler_index < 0) tiddler_index = cycle ? tiddlers.length - 1 : 0;
+			}
+			if (Date.now() - timestamp_last_navigation < INSTANT_NAVIGATION_BEFORE || INSTANT_NAVIGATION) {
+				// if user navigates quickly, jump instantly to next or previous tiddler
+				tiddlers[tiddler_index].scrollIntoView();
+			} else {
+				// scroll smoothly to next or previous tiddler
+				tiddlers[tiddler_index].scrollIntoView({behavior: "smooth", block: "start", inline: "nearest"});
+			}
+			timestamp_last_navigation = Date.now();
+			if (MARK_CURRENT_TIDDLER) {
+				if (last_tiddler_index >= 0)
+					tiddlers[last_tiddler_index].classList.remove("activeTiddler");
 				tiddlers[tiddler_index].classList.add("activeTiddler");
-		} else {
-			if (MARK_CURRENT_TIDDLER)
-				// use tiddler_index + 1 because the `tiddlers` array wasn't yet updated
-				tiddlers[tiddler_index+1].classList.add("activeTiddler");
+			}
+			getActiveTiddlersTitle();
 		}
-		getActiveTiddlersTitle();
-	} else if (e_released) {
-		// edit current tiddler
-		//tiddler_index = findTopmostTiddler(tiddlers);
-		if (tiddlers[tiddler_index] === undefined) return;
-		if (!isInViewport(tiddlers[tiddler_index])) return;
-		var button = tiddlers[tiddler_index].getElementsByClassName("tc-btn-%24%3A%2Fcore%2Fui%2FButtons%2Fedit")[0];
-		button.click();
-		getActiveTiddlersTitle();
+		else {
+			if (tiddlers[tiddler_index] === undefined) return;
+			if (!isInViewport(tiddlers[tiddler_index])) return;
+			var button = tiddlers[tiddler_index].getElementsByClassName(BTN_CLASSNAME_PREFIX+other_bind_used)[0];
+			if (!button) return;
+			button.click();
+			if ((other_bind_used == 'close' || other_bind_used == 'delete') && tiddlers.length > 1) {
+				if (tiddler_index >= tiddlers.length - 1) {
+					tiddler_index = tiddlers.length - 2;
+					if (MARK_CURRENT_TIDDLER)
+						tiddlers[tiddler_index].classList.add("activeTiddler");
+				} else {
+					if (MARK_CURRENT_TIDDLER)
+						// use tiddler_index + 1 because the `tiddlers` array wasn't yet updated
+						tiddlers[tiddler_index+1].classList.add("activeTiddler");
+				}
+			}
+			getActiveTiddlersTitle();
+		}
 	}
 };
 

--- a/keyboard-navigation.js.tid
+++ b/keyboard-navigation.js.tid
@@ -197,7 +197,7 @@ document.onkeyup = function(e) {
 	cycle = (tiddlerCycle.fields.text.trim() == "1");
 
 	var down_key_released = e.key == navigate_up_key;
-	var up_key_released = e.key == navigate_down_key;
+	var up_key_released = e.key == navigate_up_key;
 	var other_bind_used = Object.keys(bindings).find(k => bindings[k] && e.key == bindings[k])
 
 	if (tiddler_title) {

--- a/keyboard-navigation.js.tid
+++ b/keyboard-navigation.js.tid
@@ -26,7 +26,7 @@ const bindings = {
 	clone: null,
 	'export-tiddler': null,
 	edit: 'e',
-	delete: 'd',
+	delete: null,
 	permalink: null,
 	permaview: null,
 	'open-window': null,
@@ -35,6 +35,8 @@ const bindings = {
 	'fold-others': null,
 	fold: null
 }
+// if you're using an alternate keyboard layout, provide a list of key codes which should be ignored
+const alternateLayoutIgnoreKeys = ["ArrowUp"]
 // if you just want to add/change keybindings, you don't need to look further
 
 
@@ -46,6 +48,7 @@ const MARK_CURRENT_TIDDLER = true;
 // tiddler's top position should be +/- LIMIT pixels in order to be considered the topmost
 const LIMIT = 50;
 
+var ignoreKeyboardLayout = false;
 var cycle = false;
 var tiddlers;
 var tiddler_index = -1;
@@ -193,12 +196,19 @@ document.onkeyup = function(e) {
 	tiddlers = document.getElementsByClassName("tc-tiddler-frame");
 	if (tiddlers.length == 0) return;
 
+	var tiddlerIgnoreKeyboardLayout = $tw.wiki.getTiddler("$:/config/IgnoreKeyboardLayout");
+	ignoreKeyboardLayout = (tiddlerIgnoreKeyboardLayout.fields.text.trim() == "1");
+
 	var tiddlerCycle = $tw.wiki.getTiddler("$:/config/Cycle");
 	cycle = (tiddlerCycle.fields.text.trim() == "1");
 
-	var down_key_released = e.key == navigate_up_key;
-	var up_key_released = e.key == navigate_up_key;
-	var other_bind_used = Object.keys(bindings).find(k => bindings[k] && e.key == bindings[k])
+	var down_key_released = ignoreKeyboardLayout ? (e.code == ("Key" + navigate_down_key.toUpperCase())) : (e.key == navigate_down_key);
+	var up_key_released = ignoreKeyboardLayout ? (e.code == ("Key" + navigate_up_key.toUpperCase())) : (e.key == navigate_up_key);
+	var other_bind_used = Object.keys(bindings).find(k => {
+		if (!bindings[k]) return false;
+		if (ignoreKeyboardLayout) return e.code == ("Key" + bindings[k].toUpperCase()) && !alternateLayoutIgnoreKeys.find(k => k == e.key);
+		return e.key == bindings[k];
+	})
 
 	if (tiddler_title) {
 		if (tiddler_index < 0 || tiddler_index >= tiddlers.length || tiddlers[tiddler_index].getAttribute("data-tiddler-title") != tiddler_title) {
@@ -229,8 +239,8 @@ document.onkeyup = function(e) {
 				tiddler_index -= 1;
 				if (tiddler_index < 0) tiddler_index = cycle ? tiddlers.length - 1 : 0;
 			}
-			if (Date.now() - timestamp_last_navigation < INSTANT_NAVIGATION_BEFORE || INSTANT_NAVIGATION) {
-				// if user navigates quickly, jump instantly to next or previous tiddler
+			if (INSTANT_NAVIGATION || Date.now() - timestamp_last_navigation < INSTANT_NAVIGATION_BEFORE) {
+				// if user navigates quickly, or wants to navigate instantly, jump instantly to next or previous tiddler
 				tiddlers[tiddler_index].scrollIntoView();
 			} else {
 				// scroll smoothly to next or previous tiddler


### PR DESCRIPTION
Generalised the ```keyboard-navigation.js``` code so that all the tiddler buttons can be bound to something.

![image](https://user-images.githubusercontent.com/33228844/103480166-f8f1d000-4dd2-11eb-8eb7-d4a6389f81dc.png)

also put variables for the up/down navigation so that they can be easily rebound by people